### PR TITLE
Making travis build the right jar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+script:
+  - ./gradlew fatJar
 deploy:
   provider: releases
   api_key:


### PR DESCRIPTION
The travis release only seems to build a jar with no manifest, to use this from the commandline it also needs to build using the fatJar gradle task.